### PR TITLE
Aria selected and row attributes

### DIFF
--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -443,7 +443,25 @@ class FixedDataTable extends React.Component {
       footerHeight: PropTypes.number,
       groupHeaderHeight: PropTypes.number,
       headerHeight: PropTypes.number,
-    })
+    }),
+
+    /**
+     * Whether the grid is multiselectable.
+     */
+    isMultiselectable: PropTypes.bool,
+
+    /**
+     * Callback that is called when rendering a new row. Returns true if row is selected.
+     * 
+     * Required if isMultiselectable is true, optional otherwise.
+     * 
+     * ```
+     * function(
+     *   rowIndex: number
+     * )
+     * ```
+     */
+    getIsRowSelected: PropTypes.func
   }
 
   static defaultProps = /*object*/ {
@@ -660,6 +678,7 @@ class FixedDataTable extends React.Component {
       elementHeights,
       isColumnReordering,
       isColumnResizing,
+      isMultiselectable,
       maxScrollX,
       maxScrollY,
       onColumnReorderEndCallback,
@@ -849,6 +868,7 @@ class FixedDataTable extends React.Component {
         )}
         role="grid"
         aria-rowcount={ariaRowCount}
+        aria-multiselectable={isMultiselectable}
         tabIndex={tabIndex}
         onKeyDown={this._onKeyDown}
         onTouchStart={touchScrollEnabled ? this._touchHandler.onTouchStart : null}
@@ -891,6 +911,7 @@ class FixedDataTable extends React.Component {
         fixedRightColumns={fixedRightCellTemplates}
         firstViewportRowIndex={props.firstRowIndex}
         endViewportRowIndex={props.endRowIndex}
+        getIsRowSelected={props.getIsRowSelected}
         height={bodyHeight}
         offsetTop={offsetTop}
         onRowClick={props.onRowClick}

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -449,19 +449,6 @@ class FixedDataTable extends React.Component {
      * Whether the grid is multiselectable.
      */
     isMultiselectable: PropTypes.bool,
-
-    /**
-     * Callback that is called when rendering a new row. Returns true if row is selected.
-     * 
-     * Required if isMultiselectable is true, optional otherwise.
-     * 
-     * ```
-     * function(
-     *   rowIndex: number
-     * )
-     * ```
-     */
-    getIsRowSelected: PropTypes.func
   }
 
   static defaultProps = /*object*/ {
@@ -911,7 +898,6 @@ class FixedDataTable extends React.Component {
         fixedRightColumns={fixedRightCellTemplates}
         firstViewportRowIndex={props.firstRowIndex}
         endViewportRowIndex={props.endRowIndex}
-        getIsRowSelected={props.getIsRowSelected}
         height={bodyHeight}
         offsetTop={offsetTop}
         onRowClick={props.onRowClick}

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -26,6 +26,7 @@ class FixedDataTableBufferedRows extends React.Component {
     endViewportRowIndex: PropTypes.number.isRequired,
     fixedColumns: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
+    getIsRowSelected: PropTypes.func,
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
     onRowClick: PropTypes.func,
@@ -126,6 +127,8 @@ class FixedDataTableBufferedRows extends React.Component {
       rowProps.subRowHeight = this.props.rowSettings.subRowHeightGetter(rowIndex);
       rowProps.offsetTop = Math.round(baseOffsetTop + props.rowOffsets[rowIndex]);
       rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
+
+      rowProps.isSelected = props.getIsRowSelected && props.getIsRowSelected(rowIndex);
 
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) && props.showLastRowBorder;
       rowProps.className = joinClasses(

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -26,7 +26,6 @@ class FixedDataTableBufferedRows extends React.Component {
     endViewportRowIndex: PropTypes.number.isRequired,
     fixedColumns: PropTypes.array.isRequired,
     fixedRightColumns: PropTypes.array.isRequired,
-    getIsRowSelected: PropTypes.func,
     height: PropTypes.number.isRequired,
     offsetTop: PropTypes.number.isRequired,
     onRowClick: PropTypes.func,
@@ -47,6 +46,7 @@ class FixedDataTableBufferedRows extends React.Component {
     rowOffsets: PropTypes.object.isRequired,
     rowKeyGetter: PropTypes.func,
     rowSettings: PropTypes.shape({
+      rowAttributesGetter: PropTypes.func,
       rowHeightGetter: PropTypes.func,
       rowsCount: PropTypes.number.isRequired,
       subRowHeightGetter: PropTypes.func,
@@ -128,7 +128,7 @@ class FixedDataTableBufferedRows extends React.Component {
       rowProps.offsetTop = Math.round(baseOffsetTop + props.rowOffsets[rowIndex]);
       rowProps.key = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : key;
 
-      rowProps.isSelected = props.getIsRowSelected && props.getIsRowSelected(rowIndex);
+      rowProps.attributes = props.rowAttributesGetter && props.rowAttributesGetter(rowIndex);
 
       const hasBottomBorder = (rowIndex === props.rowSettings.rowsCount - 1) && props.showLastRowBorder;
       rowProps.className = joinClasses(

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -161,6 +161,11 @@ class FixedDataTableRowImpl extends React.Component {
      * The value of the aria-rowindex attribute.
      */
     ariaRowIndex: PropTypes.number,
+
+    /**
+     * Whether the row is selected.
+     */
+    isSelected: PropTypes.bool,
   };
 
   render() /*object*/ {
@@ -281,6 +286,7 @@ class FixedDataTableRowImpl extends React.Component {
         className={joinClasses(className, this.props.className)}
         role={'row'}
         aria-rowindex={this.props.ariaRowIndex}
+        aria-selected={this.props.isSelected}
         onClick={this.props.onClick ? this._onClick : null}
         onContextMenu={this.props.onContextMenu ? this._onContextMenu : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -163,9 +163,9 @@ class FixedDataTableRowImpl extends React.Component {
     ariaRowIndex: PropTypes.number,
 
     /**
-     * Whether the row is selected.
+     * DOM attributes to be applied to the row.
      */
-    isSelected: PropTypes.bool,
+    attributes: PropTypes.object,
   };
 
   render() /*object*/ {
@@ -286,7 +286,7 @@ class FixedDataTableRowImpl extends React.Component {
         className={joinClasses(className, this.props.className)}
         role={'row'}
         aria-rowindex={this.props.ariaRowIndex}
-        aria-selected={this.props.isSelected}
+        {...this.props.attributes}
         onClick={this.props.onClick ? this._onClick : null}
         onContextMenu={this.props.onContextMenu ? this._onContextMenu : null}
         onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -48,6 +48,7 @@ function getInitialState() {
     },
     rowSettings: {
       bufferRowCount: undefined,
+      rowAttributesGetter: undefined,
       rowHeight: 0,
       rowHeightGetter: () => 0,
       rowsCount: 0,
@@ -248,6 +249,7 @@ function setStateFromProps(state, props) {
     props.rowHeightGetter || (() => rowHeight);
   newState.rowSettings.subRowHeightGetter =
     props.subRowHeightGetter || (() => subRowHeight || 0);
+  newState.rowSettings.rowAttributesGetter = props.rowAttributesGetter;
 
   newState.scrollFlags = Object.assign({}, newState.scrollFlags,
     pick(props, ['overflowX', 'overflowY', 'showScrollbarX', 'showScrollbarY']));


### PR DESCRIPTION
Added further capabilities for rendering aria attributes

## Description
Added a prop onto the Table for if it is multi-selectable. Additionally, added a callback function for adding DOM element attributes to the row div.

## Motivation and Context
Creates more support for screenreaders and user customization.
Issue: https://github.com/schrodinger/fixed-data-table-2/issues/490

## How Has This Been Tested?
Given that there aren't any existing tests on DOM attributes rendered, or an installed library that would do so, I did not test these changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
